### PR TITLE
CI split unittests and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -34,10 +35,7 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.1
 
       - name: Run Tests
-        run: ./gradlew unittest -Pci
-
-      - name: Run Tests
-        run: ./gradlew integrationtest -Pci
+        run: ./gradlew test -Pci
 
       - name: JaCoCo Report
         uses: Madrapps/jacoco-report@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-
     steps:
       - uses: actions/checkout@v3
 
@@ -35,7 +34,10 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.1
 
       - name: Run Tests
-        run: ./gradlew test -Pci
+        run: ./gradlew unittest -Pci
+
+      - name: Run Tests
+        run: ./gradlew integrationtest -Pci
 
       - name: JaCoCo Report
         uses: Madrapps/jacoco-report@v1.2

--- a/bill/src/test/resources/application.properties
+++ b/bill/src/test/resources/application.properties
@@ -6,5 +6,5 @@ spring.jpa.database=POSTGRESQL
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
 # Kafka
-spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.bootstrap-servers=localhost:9096
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,50 @@ subprojects {
         finalizedBy jacocoTestReport
     }
 
+    task integrationtest(type: Test) {
+        description("Runs all integration tests and heavier tests")
+        useJUnitPlatform()
+        doFirst {
+            systemProperty 'spring.profiles.active', profile
+        }
+        filter {
+            includeTestsMatching '*ApplicationTests'
+            includeTestsMatching '*E2ETest'
+            includeTestsMatching '*EndToEndTest'
+            includeTestsMatching '*End2EndTest'
+            includeTestsMatching '*SystemTest'
+            includeTestsMatching '*IntegrationTest'
+            includeTestsMatching '*MessageTest'
+            includeTestsMatching '*EventTest'
+            includeTestsMatching '*ConsumerTest'
+            includeTestsMatching '*ProducerTest'
+            setFailOnNoMatchingTests(false)
+        }
+        finalizedBy jacocoTestReport
+    }
+
+    task unittest(type: Test) {
+        description("Runs all Unit tests and tests that don't use the Spring application context")
+        useJUnitPlatform()
+        doFirst {
+            systemProperty 'spring.profiles.active', profile
+        }
+        filter {
+            excludeTestsMatching '*ApplicationTests'
+            excludeTestsMatching '*E2ETest'
+            excludeTestsMatching '*EndToEndTest'
+            excludeTestsMatching '*End2EndTest'
+            excludeTestsMatching '*SystemTest'
+            excludeTestsMatching '*IntegrationTest'
+            excludeTestsMatching '*MessageTest'
+            excludeTestsMatching '*EventTest'
+            excludeTestsMatching '*ConsumerTest'
+            excludeTestsMatching '*ProducerTest'
+            setFailOnNoMatchingTests(false)
+        }
+        finalizedBy jacocoTestReport
+    }
+
     jacocoTestReport {
         reports {
             xml.enabled true
@@ -96,22 +140,6 @@ subprojects {
         }
     }
 
-    task unittest(type: Test) {
-        description("Runs all tests except Application, Integration and Message Tests")
-        useJUnitPlatform()
-        doFirst {
-            systemProperty 'spring.profiles.active', profile
-        }
-        filter {
-            excludeTestsMatching '*ApplicationTests'
-            excludeTestsMatching '*IntegrationTest'
-            excludeTestsMatching '*MessageTest'
-            setFailOnNoMatchingTests(false)
-        }
-        finalizedBy jacocoTestReport
-    }
-
-
 }
 
 allprojects {
@@ -119,8 +147,11 @@ allprojects {
     version = '0.0.1'
     sourceCompatibility = '17'
     testlogger {
-        theme 'mocha'
         showSimpleNames true
+        theme 'standard'
+        if (project.hasProperty('ci')) {
+            theme 'mocha'
+        }
 
         if (project.hasProperty('c') || project.hasProperty('compact')) {
             showExceptions false

--- a/common/src/main/java/com/tungstun/common/test/KafkaTestBase.java
+++ b/common/src/main/java/com/tungstun/common/test/KafkaTestBase.java
@@ -15,8 +15,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @EmbeddedKafka(
         partitions = KafkaTestBase.PARTITIONS,
         brokerProperties = {
-                "listeners=PLAINTEXT://${spring.kafka.bootstrap-servers:localhost:9092}",
-                "port=9092"
+                "listeners=PLAINTEXT://${spring.kafka.bootstrap-servers:localhost:9092}"
         }
 )
 public abstract class KafkaTestBase {

--- a/core/src/test/resources/application.properties
+++ b/core/src/test/resources/application.properties
@@ -7,5 +7,5 @@ spring.jpa.database=POSTGRESQL
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
 # Kafka
-spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVERS:localhost:9092}
+spring.kafka.bootstrap-servers=localhost:9095
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/person/src/test/resources/application.properties
+++ b/person/src/test/resources/application.properties
@@ -6,5 +6,5 @@ spring.jpa.database=POSTGRESQL
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
 # Kafka
-spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.bootstrap-servers=localhost:9094
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/product/src/test/resources/application.properties
+++ b/product/src/test/resources/application.properties
@@ -6,5 +6,5 @@ spring.jpa.database=POSTGRESQL
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
 # Kafka
-spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.bootstrap-servers=localhost:9093
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/security/src/test/resources/application.properties
+++ b/security/src/test/resources/application.properties
@@ -4,3 +4,6 @@ com.tungstun.bartap.security.jwt.jwtExpirationInMs=3000
 com.tungstun.bartap.security.jwt.jwtRefreshExpirationInMs=300000
 com.tungstun.bartap.security.jwt.jwtAudience=test-issuer
 com.tungstun.bartap.security.jwt.jwtIssuer=test-audience
+# Kafka
+spring.kafka.bootstrap-servers=localhost:9091
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
Closes #73 
Split ci tests into unittests and integration tests
Add different test kafka ports per module