### PR TITLE
Add concurrency to ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
       - main
       - development
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Add concurrency to ci tests in case of a quick succession of pushes of a pull request branch